### PR TITLE
Remove typename keyword in typedefs.

### DIFF
--- a/rapidxml_iterators.hpp
+++ b/rapidxml_iterators.hpp
@@ -18,9 +18,9 @@ namespace rapidxml
     
     public:
 
-        typedef typename xml_node<Ch> value_type;
-        typedef typename xml_node<Ch> &reference;
-        typedef typename xml_node<Ch> *pointer;
+        typedef xml_node<Ch> value_type;
+        typedef xml_node<Ch> &reference;
+        typedef xml_node<Ch> *pointer;
         typedef std::ptrdiff_t difference_type;
         typedef std::bidirectional_iterator_tag iterator_category;
         
@@ -97,9 +97,9 @@ namespace rapidxml
     
     public:
 
-        typedef typename xml_attribute<Ch> value_type;
-        typedef typename xml_attribute<Ch> &reference;
-        typedef typename xml_attribute<Ch> *pointer;
+        typedef xml_attribute<Ch> value_type;
+        typedef xml_attribute<Ch> &reference;
+        typedef xml_attribute<Ch> *pointer;
         typedef std::ptrdiff_t difference_type;
         typedef std::bidirectional_iterator_tag iterator_category;
         


### PR DESCRIPTION
g++ 6.1 and clang 3.8 indicated the following error:
/usr/local/include/rapidxml/rapidxml_iterators.hpp:21:26: error: expected a qualified name after 'typename'
        typedef typename xml_node<Ch> value_type;
Removing the useless typename solves the problem.