### PR TITLE
Update rapidxml_print.hpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# rapidxml
+This is fork of rapidxml for gcc compiller. See branch gcc_compilation - you will find correct library for gcc compiller

--- a/README.md
+++ b/README.md
@@ -1,2 +1,0 @@
-# rapidxml
-This is fork of rapidxml for gcc compiller. See branch gcc_compilation - you will find correct library for gcc compiller

--- a/rapidxml_print.hpp
+++ b/rapidxml_print.hpp
@@ -101,7 +101,41 @@ namespace rapidxml
 
         ///////////////////////////////////////////////////////////////////////////
         // Internal printing operations
+#pragma region for GCC Compilation correction
 
+    	/*
+    	 * Error compilation for gcc because of compiler can't find declaration methods...
+    	 * See more https://stackoverflow.com/questions/14113923/rapidxml-print-header-has-undefined-methods/55408678#55408678
+    	 */
+
+        template<class OutIt, class Ch>
+        inline OutIt print_children(OutIt out, const xml_node<Ch>* node, int flags, int indent);
+
+        template<class OutIt, class Ch>
+        inline OutIt print_attributes(OutIt out, const xml_node<Ch>* node, int flags);
+
+        template<class OutIt, class Ch>
+        inline OutIt print_data_node(OutIt out, const xml_node<Ch>* node, int flags, int indent);
+
+        template<class OutIt, class Ch>
+        inline OutIt print_cdata_node(OutIt out, const xml_node<Ch>* node, int flags, int indent);
+
+        template<class OutIt, class Ch>
+        inline OutIt print_element_node(OutIt out, const xml_node<Ch>* node, int flags, int indent);
+
+        template<class OutIt, class Ch>
+        inline OutIt print_declaration_node(OutIt out, const xml_node<Ch>* node, int flags, int indent);
+
+        template<class OutIt, class Ch>
+        inline OutIt print_comment_node(OutIt out, const xml_node<Ch>* node, int flags, int indent);
+
+        template<class OutIt, class Ch>
+        inline OutIt print_doctype_node(OutIt out, const xml_node<Ch>* node, int flags, int indent);
+
+        template<class OutIt, class Ch>
+        inline OutIt print_pi_node(OutIt out, const xml_node<Ch>* node, int flags, int indent);
+
+#pragma endregion
         // Print node
         template<class OutIt, class Ch>
         inline OutIt print_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);


### PR DESCRIPTION
Correction rapidxml_print.hpp for GCC compiller (error compilation - not found declaration method before using..)
https://stackoverflow.com/questions/14113923/rapidxml-print-header-has-undefined-methods/55408678#55408678