### PR TITLE
More SonarQube - refactor lookup_tables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ add_executable(rapidxml-test
         rapidxml_generator.hpp
         test/main.cc
         rapidxml_predicates.hpp
+        rapidxml_tables.hpp
 )
 target_link_libraries(rapidxml-test PRIVATE
         GTest::gtest

--- a/rapidxml_tables.hpp
+++ b/rapidxml_tables.hpp
@@ -1,0 +1,288 @@
+//
+// Created by dwd on 9/7/24.
+//
+
+#ifndef RAPIDXML_RAPIDXML_TABLES_HPP
+#define RAPIDXML_RAPIDXML_TABLES_HPP
+
+#include <vector>
+#include <array>
+
+///////////////////////////////////////////////////////////////////////
+// Internals
+
+//! \cond internal
+namespace rapidxml::internal {
+
+    // Struct that contains lookup tables for the parser
+    struct lookup_tables {
+        // Whitespace (space \n \r \t)
+        static inline const std::vector<bool> lookup_whitespace =
+                {
+                        // 0   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
+                        false,  false,  false,  false,  false,  false,  false,  false,  false,  true ,  true ,  false,  false,  true ,  false,  false,  // 0
+                        false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  // 1
+                        true ,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  // 2
+                        false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  // 3
+                        false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  // 4
+                        false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  // 5
+                        false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  // 6
+                        false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  // 7
+                        false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  // 8
+                        false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  // 9
+                        false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  // A
+                        false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  // B
+                        false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  // C
+                        false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  // D
+                        false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  // E
+                        false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false,  false   // F
+                };
+
+        // Element name (anything but space \n \r \t / > ? \0 and :)
+        static inline const std::vector<bool> lookup_element_name =
+                {
+                        // 0   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
+                        false,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  false,  false,  true ,  true ,  false,  true ,  true ,  // 0
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 1
+                        false,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  false,  // 2
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  false,  true ,  true ,  true ,  false,  false,  // 3
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 4
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 5
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 6
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 7
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 8
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 9
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // A
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // B
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // C
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // D
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // E
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  1   // F
+                };
+
+        // Node name (anything but space \n \r \t / > ? \0)
+        static inline const std::vector<bool> lookup_node_name =
+                {
+                        // 0   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
+                        false,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  false,  false,  true ,  true ,  false,  true ,  true ,  // 0
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 1
+                        false,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  false,  // 2
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  false,  false,  // 3
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 4
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 5
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 6
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 7
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 8
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 9
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // A
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // B
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // C
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // D
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // E
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  1   // F
+                };
+
+        // Text (i.e. PCDATA) (anything but < \0)
+        static inline const std::vector<bool> lookup_text =
+                {
+                        // 0   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
+                        false,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 0
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 1
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 2
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  false,  true ,  true ,  true ,  // 3
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 4
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 5
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 6
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 7
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 8
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 9
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // A
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // B
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // C
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // D
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // E
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  1   // F
+                };
+
+        // Text (i.e. PCDATA) that does not require processing when ws normalization is disabled
+        // (anything but < \0 &)
+        static inline const std::vector<bool> lookup_text_pure_no_ws =
+                {
+                        // 0   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
+                        false,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 0
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 1
+                        true ,  true ,  true ,  true ,  true ,  true ,  false,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 2
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  false,  true ,  true ,  true ,  // 3
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 4
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 5
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 6
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 7
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 8
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 9
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // A
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // B
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // C
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // D
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // E
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  1   // F
+                };
+
+        // Text (i.e. PCDATA) that does not require processing when ws normalizationis is enabled
+        // (anything but < \0 & space \n \r \t)
+        static inline const std::vector<bool> lookup_text_pure_with_ws =
+                {
+                        // 0   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
+                        false,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  false,  false,  true ,  true ,  false,  true ,  true ,  // 0
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 1
+                        false,  true ,  true ,  true ,  true ,  true ,  false,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 2
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  false,  true ,  true ,  true ,  // 3
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 4
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 5
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 6
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 7
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 8
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 9
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // A
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // B
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // C
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // D
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // E
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  1   // F
+                };
+
+        // Attribute name (anything but space \n \r \t / < > = ? ! \0)
+        static inline const std::vector<bool> lookup_attribute_name =
+                {
+                        // 0   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
+                        false,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  false,  false,  true ,  true ,  false,  true ,  true ,  // 0
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 1
+                        false,  false,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  false,  // 2
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  false,  false,  false,  false,  // 3
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 4
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 5
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 6
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 7
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 8
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 9
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // A
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // B
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // C
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // D
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // E
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  1   // F
+                };
+
+        // Attribute data with single quote (anything but ' \0)
+        static inline const std::vector<bool> lookup_attribute_data_1 =
+                {
+                        // 0   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
+                        false,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 0
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 1
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  false,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 2
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 3
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 4
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 5
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 6
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 7
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 8
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 9
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // A
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // B
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // C
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // D
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // E
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  1   // F
+                };
+
+        // Attribute data with single quote that does not require processing (anything but ' \0 &)
+        static inline const std::vector<bool> lookup_attribute_data_1_pure =
+                {
+                        // 0   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
+                        false,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 0
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 1
+                        true ,  true ,  true ,  true ,  true ,  true ,  false,  false,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 2
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 3
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 4
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 5
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 6
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 7
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 8
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 9
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // A
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // B
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // C
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // D
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // E
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  1   // F
+                };
+
+        // Attribute data with double quote (anything but " \0)
+        static inline const std::vector<bool> lookup_attribute_data_2 =
+                {
+                        // 0   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
+                        false,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 0
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 1
+                        true ,  true ,  false,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 2
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 3
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 4
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 5
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 6
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 7
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 8
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 9
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // A
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // B
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // C
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // D
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // E
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  1   // F
+                };
+
+        // Attribute data with double quote that does not require processing (anything but " \0 &)
+        static inline const std::vector<bool> lookup_attribute_data_2_pure =
+                {
+                        // 0   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
+                        false,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 0
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 1
+                        true ,  true ,  false,  true ,  true ,  true ,  false,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 2
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 3
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 4
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 5
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 6
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 7
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 8
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // 9
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // A
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // B
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // C
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // D
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  // E
+                        true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true ,  true   // F
+                };
+
+        // Digits (dec and hex, 255 denotes end of numeric character reference)
+        static inline const std::array<unsigned char, 256> lookup_digits =
+                {
+                        // 0   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
+                        255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,  // 0
+                        255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,  // 1
+                        255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,  // 2
+                        0,  1,  2,  3,  4,  5,  6,  7,  8,  9,255,255,255,255,255,255,  // 3
+                        255, 10, 11, 12, 13, 14, 15,255,255,255,255,255,255,255,255,255,  // 4
+                        255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,  // 5
+                        255, 10, 11, 12, 13, 14, 15,255,255,255,255,255,255,255,255,255,  // 6
+                        255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,  // 7
+                        255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,  // 8
+                        255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,  // 9
+                        255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,  // A
+                        255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,  // B
+                        255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,  // C
+                        255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,  // D
+                        255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,  // E
+                        255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255   // F
+                };
+    };
+}
+//! \endcond
+
+#endif //RAPIDXML_RAPIDXML_TABLES_HPP

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,5 +13,6 @@ sonar.organization=dwd-github
 #sonar.sourceEncoding=UTF-8
 
 
-sonar.exclusions=**/deps/**, **/_deps/**, **/sentry-native/**, **/*.html
+sonar.exclusions=**/deps/**, **/_deps/**, **/sentry-native/**, **/*.html, **/googletest/**
 sonar.sources=.
+sonar.coverage.exclusions=**/deps/**,**/_deps/**,**/sentry-native/**,**/*.html,**/googletest/**,**/test/**

--- a/test/parse-simple.cpp
+++ b/test/parse-simple.cpp
@@ -31,6 +31,8 @@ TEST(Parser, DefaultElementNS) {
     EXPECT_EQ(child->name(), "child");
     EXPECT_EQ(child->xmlns(), "this");
     doc.validate();
+    auto no_node = child->next_sibling();
+    EXPECT_THROW(no_node->xmlns(), rapidxml::no_such_node);
 }
 
 TEST(Parser, UnboundPrefix) {

--- a/test/round-trips.cpp
+++ b/test/round-trips.cpp
@@ -63,6 +63,10 @@ TEST(RoundTrip, SimpleMod) {
     EXPECT_EQ(check->name(), name);
     EXPECT_EQ(check->name().data(), name.data());
     EXPECT_EQ(output3, "<pfx:simple xmlns:pfx=\"this\"><this>the other</this><this>another&apos;</this><odd>the other</odd><this xmlns=\"that\">the other</this><pfx:that>the other</pfx:that><this>last time</this></pfx:simple>");
+    rapidxml::xml_document<> doc2;
+    doc2.clone_node(doc.first_node(), true);
+    auto output4 = print(doc);
+    EXPECT_EQ(output3, output4);
 }
 
 TEST(RoundTrip, SimpleApos) {


### PR DESCRIPTION
The original lookup tables were inline defined unsigned char arrays, mostly of 0 or 1.

This changes them to (mostly) std::vector<bool> arrays, with one remaining set to std::array<unsigned char, 256>.

The original defined these as static variables within a templatized struct as a linkage hack; we're now using C++17's `static inline` instead which achieves the same thing.