### PR TITLE
Import node_type into rapidxml namespace

### DIFF
--- a/rapidxml.hpp
+++ b/rapidxml.hpp
@@ -176,6 +176,7 @@ namespace rapidxml
         node_pi,            //!< A PI node. Name contains target. Value contains instructions.
 	    node_literal        //!< Value is unencoded text (used for inserting pre-rendered XML).
     };
+    using enum node_type; // Import this into the rapidxml namespace as before.
 
     ///////////////////////////////////////////////////////////////////////
     // Parsing flags
@@ -871,8 +872,6 @@ namespace rapidxml
     template<typename Ch = char>
     class xml_node: public xml_base<Ch>
     {
-        using enum node_type;
-
     public:
         using view_type = std::basic_string_view<Ch>;
         using ptr = optional_ptr<xml_node<Ch>>;
@@ -1594,8 +1593,6 @@ namespace rapidxml
     template<class Ch = char>
     class xml_document: public xml_node<Ch>, public memory_pool<Ch>
     {
-        using enum node_type;
-
     public:
         using view_type = std::basic_string_view<Ch>;
         using ptr = optional_ptr<xml_document<Ch>>;

--- a/rapidxml_print.hpp
+++ b/rapidxml_print.hpp
@@ -370,8 +370,6 @@ namespace rapidxml
             // Print proper node type
             switch (node->type())
             {
-                using enum node_type;
-
             // Document
             case node_document:
                 out = print_children(out, node, flags, indent);

--- a/test/manipulations.cpp
+++ b/test/manipulations.cpp
@@ -17,7 +17,7 @@ namespace {
 
 TEST(Create, Node) {
     rapidxml::xml_document<> doc;
-    auto node = doc.allocate_node(rapidxml::node_type::node_element, "fish", "cakes");
+    auto node = doc.allocate_node(rapidxml::node_element, "fish", "cakes");
     doc.append_node(node);
 
     EXPECT_EQ(
@@ -28,7 +28,7 @@ TEST(Create, Node) {
 
 TEST(Create, NodeEmpty) {
     rapidxml::xml_document<> doc;
-    auto node = doc.allocate_node(rapidxml::node_type::node_element, "fish");
+    auto node = doc.allocate_node(rapidxml::node_element, "fish");
     doc.append_node(node);
 
     EXPECT_EQ(
@@ -39,7 +39,7 @@ TEST(Create, NodeEmpty) {
 
 TEST(Create, Node2) {
     rapidxml::xml_document<> doc;
-    auto node = doc.allocate_node(rapidxml::node_type::node_element, "fish", "cakes");
+    auto node = doc.allocate_node(rapidxml::node_element, "fish", "cakes");
     doc.append_node(node);
 
     EXPECT_EQ(
@@ -56,7 +56,7 @@ std::string const & fn() {
 
 TEST(Create, NodeAttr) {
     rapidxml::xml_document<> doc;
-    auto node = doc.allocate_node(rapidxml::node_type::node_element, "fish", "cakes");
+    auto node = doc.allocate_node(rapidxml::node_element, "fish", "cakes");
     auto haddock = doc.allocate_attribute("id", "haddock");
     node->append_attribute(haddock);
     doc.append_node(node);


### PR DESCRIPTION
Essentially this reverts a breaking change in usage terms.