### PR TITLE
Use buffer_ptr inside predicate skips

### DIFF
--- a/test/low-level-parse.cpp
+++ b/test/low-level-parse.cpp
@@ -35,31 +35,31 @@ TEST(PredicateBuffer, Skip) {
 TEST(Predicates, SkipAndExpand) {
     std::string test_data{"&hello;<"};
     char * start = const_cast<char *>(test_data.c_str());
-    start = rapidxml::xml_document<>::skip_and_expand_character_refs<
+    auto end = rapidxml::xml_document<>::skip_and_expand_character_refs<
             rapidxml::xml_document<>::text_pred,
             rapidxml::xml_document<>::text_pure_with_ws_pred,
             rapidxml::parse_no_entity_translation>(start);
-    EXPECT_EQ(*start, '<');
+    EXPECT_EQ(*end, '<');
 }
 
 TEST(Predicates, SkipAndExpandShort) {
     std::string test_data{"&hello;"};
     char * start = const_cast<char *>(test_data.c_str());
-    start = rapidxml::xml_document<>::skip_and_expand_character_refs<
+    auto end = rapidxml::xml_document<>::skip_and_expand_character_refs<
             rapidxml::xml_document<>::text_pred,
             rapidxml::xml_document<>::text_pure_with_ws_pred,
             rapidxml::parse_no_entity_translation>(start);
-    EXPECT_EQ(*start, '\0');
+    EXPECT_EQ(*end, '\0');
 }
 
 TEST(Predicates, SkipAndExpandShorter) {
     std::string test_data{"&hell"};
     char * start = const_cast<char *>(test_data.c_str());
-    start = rapidxml::xml_document<>::skip_and_expand_character_refs<
+    auto end = rapidxml::xml_document<>::skip_and_expand_character_refs<
             rapidxml::xml_document<>::text_pred,
             rapidxml::xml_document<>::text_pure_with_ws_pred,
             rapidxml::parse_no_entity_translation>(start);
-    EXPECT_EQ(*start, '\0');
+    EXPECT_EQ(*end, '\0');
 }
 
 TEST(ParseFns, ParseBom) {


### PR DESCRIPTION
While I can't reproduce this bug in the test suite, I suspect that in some cases the value decoding will run over the end of the buffer.

This is because the buffer is not NUL terminated, and the code was originally expecting to perform this in-situ on the original buffer, which was both NUL-terminated and within known delimiters.