### PR TITLE
print: fix unused flag warning

### DIFF
--- a/include/flxml/print.h
+++ b/include/flxml/print.h
@@ -127,7 +127,7 @@ namespace flxml
 
         // Print attributes of the node
         template<class OutIt, class Ch>
-        inline OutIt print_attributes(OutIt out, const optional_ptr<xml_node<Ch>> node, int flags)
+        inline OutIt print_attributes(OutIt out, const optional_ptr<xml_node<Ch>> node, int)
         {
             for (auto attribute = node->first_attribute(); attribute; attribute = attribute->next_attribute())
             {


### PR DESCRIPTION
The unused `flag` variable causes a warning. This is fixed by removing the name from the signature.